### PR TITLE
ODP-5225: Allow repositories without defined parents to sync tags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ version = "0.4.0"
 
 
 [dependencies]
-aws-config = { version = "1.8.6", features = ["rustls"], optional = true }
-aws-lc-rs = "1.13"
-aws-sdk-s3 = { version = "1.105", optional = true }
+aws-config = { version = "1.8.7", features = ["rustls"], optional = true }
+aws-lc-rs = "1.14.1"
+aws-sdk-s3 = { version = "1.107", optional = true }
 chrono = { version = "0.4", features = ["clock", "iana-time-zone", "std"] }
 clap = { version = "4.5", features = ["derive", "env", "unicode", "wrap_help"] }
-clap_complete = "4.5.57"
+clap_complete = "4.5.58"
 clap_mangen = "0.2.29"
-console = "0.16.0"
+console = "0.16.1"
 fancy-regex = "0.16"
 flate2 = { version = "1.1.2", default-features = false, features = ["zlib-ng"] }
 futures = { version = "0.3.31", features = ["alloc", "async-await", "std"] }
@@ -23,6 +23,7 @@ hyper = { version = "1.7.0", default-features = false }
 iana-time-zone = "0.1"
 indexmap = { version = "2.11", features = ["serde"] }
 indicatif = { version = "0.18.0", features = ["tokio"] }
+microxdg = "0.2.0"
 octocrab = { version = "0.46", default-features = false, features = [
   "default-client",
   "follow-redirect",
@@ -46,33 +47,31 @@ rustls = { version = "0.23", features = ["aws_lc_rs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tabled = { version = "0.20", features = ["ansi", "macros", "std"] }
+tar = "0.4.44"
 temp-dir = "0.1"
 thiserror = "2.0"
 tokio = { version = "1.47", features = ["macros", "rt-multi-thread"] }
 tokio-retry = "0.3"
-toml = "0.9.5"
-
-microxdg = "0.2.0"
-sqlx = { version = "0.8.6", optional = true, default-features = false, features = [
-  "chrono",
-  "derive",
-  "json",
-  "macros",
-  "migrate",
-  "runtime-tokio-rustls",
-  "time",
-  "tls-rustls-aws-lc-rs",
-] }
-tar = "0.4.44"
+toml = "0.9"
+#sqlx = { version = "0.8.6", optional = true, default-features = false, features = [
+#  "chrono",
+#  "derive",
+#  "json",
+#  "macros",
+#  "migrate",
+#  "runtime-tokio-rustls",
+#  "time",
+#  "tls-rustls-aws-lc-rs",
+#] }
 walkdir = "2.5.0"
 
 [features]
-aws      = ["dep:aws-config", "dep:aws-sdk-s3"]
-default  = ["aws", "slack"]
-postgres = ["sql", "sqlx/postgres"]
-slack    = []
-sql      = ["dep:sqlx"]
-sqlite   = ["sql", "sqlx/sqlite"]
+aws     = ["dep:aws-config", "dep:aws-sdk-s3"]
+default = ["aws", "slack"]
+#postgres = ["sql", "sqlx/postgres"]
+slack = []
+#sql      = ["dep:sqlx"]
+#sqlite   = ["sql", "sqlx/sqlite"]
 
 [profile.release]
 lto   = true

--- a/src/github/match_args.rs
+++ b/src/github/match_args.rs
@@ -236,7 +236,9 @@ async fn match_tag_cmds(
                             .sync_tags(repository, Some(parent), process_annotated_tags)
                             .await?;
                     } else {
-                        client.sync_tags(repository, None, process_annotated_tags).await?;
+                        client
+                            .sync_tags(repository, None, process_annotated_tags)
+                            .await?;
                     }
                 } else {
                     return Err(GitError::MissingRepositoryName);

--- a/src/github/match_args.rs
+++ b/src/github/match_args.rs
@@ -179,12 +179,11 @@ async fn match_tag_cmds(
     client: &GithubClient,
     repos: Vec<String>,
     cmd: &TagCommand,
-    _fork_workaround: HashMap<String, String>,
+    fork_workaround: HashMap<String, String>,
 ) -> Result<(), GitError> {
     let result = async {
         match cmd {
             TagCommand::Compare(compare_cmd) => {
-                //compare_cmd.validate().map_err(GitError::Other)?;
                 let repository = compare_cmd.repository.as_ref();
                 if compare_cmd.all && !repos.is_empty() {
                     client.diff_all_tags(repos).await?;
@@ -226,12 +225,19 @@ async fn match_tag_cmds(
                 let repository = sync_cmd.repository.as_ref();
                 // By default, this is false
                 let process_annotated_tags = sync_cmd.with_annotated;
+
                 if sync_cmd.all {
                     client
-                        .sync_all_tags(process_annotated_tags, &repos[..])
+                        .sync_all_tags(process_annotated_tags, &repos[..], fork_workaround)
                         .await?;
                 } else if let Some(repository) = repository {
-                    client.sync_tags(repository, process_annotated_tags).await?;
+                    if let Some(parent) = fork_workaround.get(repository) {
+                        client
+                            .sync_tags(repository, Some(parent), process_annotated_tags)
+                            .await?;
+                    } else {
+                        return Err(GitError::NoUpstreamRepo);
+                    }
                 } else {
                     return Err(GitError::MissingRepositoryName);
                 }

--- a/src/github/match_args.rs
+++ b/src/github/match_args.rs
@@ -236,7 +236,7 @@ async fn match_tag_cmds(
                             .sync_tags(repository, Some(parent), process_annotated_tags)
                             .await?;
                     } else {
-                        return Err(GitError::NoUpstreamRepo);
+                        client.sync_tags(repository, None, process_annotated_tags).await?;
                     }
                 } else {
                     return Err(GitError::MissingRepositoryName);


### PR DESCRIPTION
This makes it so repositories like Livy and Kafka3 can sync their tags with their upstream parent repository by putting them in the fork_workaround hash map (where {url:parent_url}) that was previously being used for syncing and updating branches.

I've also bumped a few minor versions for libraries here after I saw they had been updated. Since there isn't any sql integration at this point, I've also commented out the dependency which can cause a medium severity CVE to be reported.