### PR TITLE
ODP-5236: Update change-version to be modify

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - Sync changes between a fork and its parent repository.
 - Sync tags from upstream to your forked repository.
 - Create/delete branches.
-  - Including changing the versions of software within a repository
+- Change text in a branch
 - Create/delete tags.
 - Create releases with automatically generated release notes.
 - Create and automatically merge pull requests, where possible.
@@ -282,15 +282,21 @@ You can create and delete branches for a single repository or for all configured
 $ git_sync branch create --all --new-branch rel/ODP-3.3.6.2-101 --base-branch ODP-3.3.6.2-1
 # Or, create a branch from an existing tag
 $ git_sync branch create --all --new-branch rel/ODP-3.3.6.2-101 --base-tag ODP-3.3.6.2-1-tag
-# Optionally, update the ODP version for the branch you just created
-$ git_sync branch change-version --all --branch rel/ODP-3.3.6.2-101 --old-version 3.3.6.2-1 --new-version 3.3.6.2-101
+# Optionally update the ODP version for the new branch you've created
+$ git_sync branch modify --all --branch rel/ODP-3.3.6.2-101 --old 3.3.6.2-1 --new 3.3.6.2-101
 # Or update actions/upload-artifact@v3 to actions/upload-artifact@v4 for a repository
-$ git_sync branch change-version -r https://github.com/acceldata-io/nifi --branch my_branch --old-version actions/upload-artifact@v3 --new-version actions/upload-artifact@v4
+$ git_sync branch modify -r https://github.com/acceldata-io/nifi --not-version --branch my_branch --old actions/upload-artifact@v3 --new actions/upload-artifact@v4
 # Delete a branch
 $ git_sync branch delete --all --branch my_branch_name
 ```
 
+
 At the moment, running `branch delete` will immediately delete the branch without any confirmation. A future feature planned is a configurable delete queue that will create a 'cooling off' period before actually deleting the branch in order to avoid deleting branches permanently by accident. Support for this will come along with any SQL features since that will allow for persistent storage.
+
+Notes for the `branch modify` command:
+  - odp-bigtop has a specific workaround involving version numbers, file names, and build numbers. If you do not want this behaviour (ie you are modifying something other than a version number), you can specify the `--not-version` flag to disable this behaviour.
+  - The `--not-version` flag also changes the automated commit message to be more generic for any `branch modify` subcommand
+  - `--message <custom message>` can be used to specify whatever commit message you would like. Without this, a message prefixed with [Automated] will be used.
 
 ### Managing tags
 Managing tags is very similar to managing branches. You can create and delete lightweight tags for a single repository or for all configured repositories. If you want to create an annotated tag, you must use git directly and create it yourself.

--- a/README.md
+++ b/README.md
@@ -228,14 +228,22 @@ If you want to include your `fork_with_workaround` repositories in the backup, y
 
 
 #### Local backup
-Ensure you have enough space on your local filesystem to house all of your backups since these can be surprisingly large. For example, a `git clone --mirror` of [ClickHouse](https://github.com/ClickHouse/ClickHouse) is around 1.8GB on its own. You must have read-write access to this folder.
+Ensure you have enough space on your local filesystem to house all of your backups since these can be surprisingly large. For example, a `git clone --mirror` of [ClickHouse](https://github.com/ClickHouse/ClickHouse) is around 1.8GB on its own. You must have read write access to this folder; if you do not, any backup operation will fail.
 
+You can also optionally enable a repository blacklist, if there are repositories you do not wish to be included in a particular backup. This can be enabled by adding 
+```toml
+[misc]
+backup_blacklist = ["https://github.com/my-org/repository"]
+```
+to your configuration file.  
 
-Importantly, the path you pick here must be a folder. 
+To then enable your blacklist, pass `--blacklist` to any backup operation. This option can be useful when you have very large repositories that you don't need to backup every time, but may wish to sometimes backup since you can remove the `--blacklist` flag to then update everything. 
+
+Importantly, the path you pick here must either be a folder or not exist. If it does not exist, it will be created automatically. 
 ```bash
 $ git_sync backup create -r https://github.com/my-org/my-repo --path /path/to/backup/folder 
 $ git_sync backup create --all -p /path/to/backup/folder --slack
-# Backing up every single repsitory listed in the configuration file
+# Backing up every single repository listed in the configuration file
 $ git_sync backup create --repository-type all -p /path/to/backup/folder --slack
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -500,26 +500,33 @@ pub struct DeleteBranchCommand {
     long_about = "
 Examples:
     # Change the version from 3.3.6.2-1 to 3.3.6.2-101
-    git_sync branch change-version --all --branch ODP-3.3.6.2-1 --old-version 3.3.6.2-1 --new-version 3.3.6.2-101
+    git_sync branch change --all --branch ODP-3.3.6.2-1 --old 3.3.6.2-1 --new 3.3.6.2-101
 Notes:
     This action is a regex match and replace, so be careful what you pass as the old version.
     Strictly speaking, this can be used to replace any matching regex within a repository
+
+    If you run this against odp-bigtop in order to update its version, make sure that `is-version` is true.
+    This ensures that it will correctly update filenames and other odp-bigtop specific changes.
 "
 )]
-pub struct ChangeVersionCommand {
-    /// Change the version of a branch in a repository
+pub struct ChangeBranchTextCommand {
+    /// Change text of a branch in a repository
     #[arg(short, long)]
     pub repository: Option<String>,
-    /// Branch to change version in
+    /// Branch to change text in
     #[arg(short, long)]
     pub branch: String,
-    /// The old version you wish to change
+    /// The old text you wish to change
     #[arg(short, long)]
-    pub old_version: String,
-    /// The new version you want to change it to
+    pub old: String,
+    /// The new text you want to change it to
     #[arg(short, long)]
-    pub new_version: String,
-    /// Change the version for the specified branch across all configured repositories
+    pub new: String,
+    /// Specify that the text you're modifying is a version. This affects the default commit
+    /// message as well as running additional steps for odp-bigtop.
+    #[arg(long, default_value_t = false)]
+    pub not_version: bool,
+    /// Change the text for the specified branch across all configured repositories
     #[arg(short, long, default_value_t = false)]
     pub all: bool,
     /// An optional commit message to override the automatic commit message
@@ -713,12 +720,12 @@ pub enum RepoCommand {
 /// Define all the valid commands for acting on branches
 #[derive(Subcommand, Clone, Debug)]
 pub enum BranchCommand {
-    /// Delete a branch in repositories
-    Delete(DeleteBranchCommand),
     /// Create a branch for repositories
     Create(CreateBranchCommand),
-    /// Change version in a branch for repositories
-    ChangeVersion(ChangeVersionCommand),
+    /// Delete a branch in repositories
+    Delete(DeleteBranchCommand),
+    /// Modify text in a branch for repositories
+    Modify(ChangeBranchTextCommand),
 }
 
 /// The top-level command enum for the CLI

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -619,6 +619,11 @@ pub struct BackupRepoCommand {
     /// currently.
     #[arg(short, long, default_value_t = false)]
     pub update: bool,
+    /// Enable the backup blacklist to prevent repositories from being backed up from the
+    /// `backup_blacklist` set in git-manage.toml. This option will be ignored if
+    /// `--repository` is specified
+    #[arg(long, default_value_t = false)]
+    pub blacklist: bool,
     /// Bucket name for where you want to store your backup if using `S3`
     #[cfg(feature = "aws")]
     #[arg(short, long, required_if_eq("destination", "s3"))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,7 @@ pub struct Config {
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[allow(clippy::struct_field_names)]
 pub struct MiscSettings {
     /// A blacklist for branches when searching for stale ones.
     /// This allows you to ignore long living branches that should always exist
@@ -61,6 +62,10 @@ pub struct MiscSettings {
     /// A blacklist for licenses. If one of your repositories has one of these licenses, you will
     /// get a warning about it
     pub license_blacklist: Option<HashSet<String>>,
+    /// A blacklist for repositories when you are backing up.
+    /// This allows you to say that you don't want to back up certain repositories, even when
+    /// selecting 'all' as your backup target
+    pub backup_blacklist: Option<HashSet<String>>,
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/src/github/match_args.rs
+++ b/src/github/match_args.rs
@@ -301,34 +301,38 @@ async fn match_branch_cmds(
                 client.delete_branch(repository, &delete_cmd.branch).await?;
             }
         }
-        BranchCommand::ChangeVersion(change_version_cmd) => {
-            let repository = change_version_cmd.repository.clone();
-            let message = change_version_cmd.message.clone();
-            let (branch, old_version, new_version) = (
-                change_version_cmd.branch.clone(),
-                change_version_cmd.old_version.clone(),
-                change_version_cmd.new_version.clone(),
+        BranchCommand::Modify(modify_cmd) => {
+            let repository = modify_cmd.repository.clone();
+            let message = modify_cmd.message.clone();
+            // Awkwardly named, I know, but since it's a boolean we don't have too many options
+            let is_version = !modify_cmd.not_version;
+            let (branch, old_text, new_text) = (
+                modify_cmd.branch.clone(),
+                modify_cmd.old.clone(),
+                modify_cmd.new.clone(),
             );
-            if change_version_cmd.all {
+            if modify_cmd.all {
                 client
-                    .change_all_release_version(
+                    .modify_all_branches(
                         branch,
-                        old_version,
-                        new_version,
+                        old_text,
+                        new_text,
                         &repos[..],
                         message,
                         dry_run,
+                        is_version,
                     )
                     .await?;
             } else if let Some(repository) = &repository {
                 client
-                    .change_release_version(
+                    .modify_branch(
                         repository.to_string(),
                         branch,
-                        old_version,
-                        new_version,
+                        old_text,
+                        new_text,
                         message,
                         dry_run,
+                        is_version,
                     )
                     .await?;
             }


### PR DESCRIPTION
This modifies change-version to modify, in order to better represent what it is. It isn't limited to only changing ODP versions, and can be used with any simple match/replace text handling. 

This means that things like the `#!/usr/bin/python3` to `#!/usr/bin/env ambari-python-wrap` could in future be changed by using this command, instead of doing it manually.
