### PR TITLE
Cleanup error types and messages

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -505,7 +505,7 @@ Notes:
     This action is a regex match and replace, so be careful what you pass as the old version.
     Strictly speaking, this can be used to replace any matching regex within a repository
 
-    If you run this against odp-bigtop in order to update its version, make sure that `is-version` is true.
+    If you run this against odp-bigtop in order to update its version, make sure that `--not-version` is *not* specified.
     This ensures that it will correctly update filenames and other odp-bigtop specific changes.
 "
 )]

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -127,7 +127,10 @@ impl GithubClient {
 
         let parent = *repo_info.parent.ok_or(GitError::NotAFork)?;
 
-        let parent_owner = parent.owner.ok_or(GitError::NoUpstreamRepo)?.login;
+        let parent_owner = parent
+            .owner
+            .ok_or(GitError::NoUpstreamRepo(url.as_ref().to_string()))?
+            .login;
 
         let url = parent
             .html_url

--- a/src/github/fork.rs
+++ b/src/github/fork.rs
@@ -401,17 +401,16 @@ impl GithubClient {
                     no_update += is_updated;
                 } else {
                     eprintln!("Skipping branch {branch} due to non-fast-forward merge");
-                    errors.push(GitError::Other(format!(
-                        "Skipping branch {branch} due to non-fast-forward merge"
-                    )));
+                    errors.push(GitError::GitFFMergeError {
+                        branch: branch.to_string(),
+                        repository: ssh_url.to_string(),
+                    });
                 }
             }
 
             // If no branches were synced, and there are errors, then we return an error
             if successful == 0 && !errors.is_empty() {
-                return Err(GitError::Other(
-                    "No branches were successfully synced".to_string(),
-                ));
+                return Err(GitError::GitPushError(ssh_url.to_string()));
             }
 
             Command::new("git")

--- a/src/github/match_args.rs
+++ b/src/github/match_args.rs
@@ -75,13 +75,11 @@ pub async fn match_arguments(app: &AppArgs, config: Config) -> Result<(), GitErr
                 .cloned();
             if let Some(repository) = &repository {
                 if repository.is_empty() {
-                    return Err(GitError::Other(format!(
-                        "No repositories found for custom group '{name}'"
-                    )));
+                    return Err(GitError::EmptyGroup(name));
                 }
                 repository.clone()
             } else {
-                return Err(GitError::Other(format!("Custom group '{name}' not found")));
+                return Err(GitError::InvalidGroup(name));
             }
         }
     };
@@ -122,21 +120,26 @@ pub async fn match_arguments(app: &AppArgs, config: Config) -> Result<(), GitErr
         }
     }
 
-    match &app.command {
+    let result = match &app.command {
         Command::Tag { cmd } => {
-            match_tag_cmds(&client, repos, cmd, fork_workaround_repositories).await?;
+            match_tag_cmds(&client, repos, cmd, fork_workaround_repositories).await
         }
         Command::Repo { cmd } => {
-            match_repo_cmds(&client, repos, config, cmd, fork_workaround_repositories).await?;
+            match_repo_cmds(&client, repos, config, cmd, fork_workaround_repositories).await
         }
-        Command::Branch { cmd } => match_branch_cmds(&client, repos, cmd, quiet, dry_run).await?,
-        Command::Release { cmd } => match_release_cmds(&client, repos, config, cmd).await?,
-        Command::PR { cmd } => match_pr_cmds(&client, repos, config, cmd).await?,
+        Command::Branch { cmd } => match_branch_cmds(&client, repos, cmd, quiet, dry_run).await,
+        Command::Release { cmd } => match_release_cmds(&client, repos, config, cmd).await,
+        Command::PR { cmd } => match_pr_cmds(&client, repos, config, cmd).await,
         Command::Backup { cmd } => {
-            match_backup_cmds(&client, repos, config, cmd, fork_workaround_repositories).await?;
+            match_backup_cmds(&client, repos, config, cmd, fork_workaround_repositories).await
         }
         Command::Config { file, force } => {
-            generate_config(file.as_ref(), *force)?;
+            let generate = generate_config(file.as_ref(), *force);
+            if generate.is_ok() {
+                Ok(())
+            } else {
+                Err(generate.err().unwrap())
+            }
         }
         Command::Generate { kind, out } => {
             let mut cmd = cli();
@@ -163,15 +166,16 @@ pub async fn match_arguments(app: &AppArgs, config: Config) -> Result<(), GitErr
                 }
                 _ => {}
             }
+            Ok(())
         }
-    }
+    };
     // despite collecting the messages and errors always, we only actually send them to slack if
     // it's enabled.
     #[cfg(feature = "slack")]
     if app.slack {
         client.slack_message().await;
     }
-    Ok(())
+    if let Err(e) = result { Err(e) } else { Ok(()) }
 }
 
 /// Process all Tag commands
@@ -372,9 +376,7 @@ async fn match_repo_cmds(
                 if let Some(parent) = fork_workaround.get(repository) {
                     client.sync_with_upstream(repository, parent).await?;
                 } else if forks_with_workaround.contains_key(repository) {
-                    return Err(GitError::Other(format!(
-                        "Repository '{repository}' has no configured parent. Use the '--with-fork-workaround' flag to enable syncing it."
-                    )));
+                    return Err(GitError::NoUpstreamRepo(repository.to_string()));
                 } else if recursive {
                     client.sync_fork_recursive(repository).await?;
                 } else {

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -128,12 +128,15 @@ impl GithubClient {
                 },
             );
             match pr_result {
-                Ok(p) => p.items.first().map(|pr| pr.number).ok_or_else(|| {
-                    GitError::Other(format!(
-                        "Cannot get existing PR number for {owner}/{repo} with head {} and base {}",
-                        opts.head, opts.base
-                    ))
-                })?,
+                Ok(p) => p
+                    .items
+                    .first()
+                    .map(|pr| pr.number)
+                    .ok_or_else(|| GitError::NoSuchPR {
+                        repository: format!("{owner}/{repo}"),
+                        head: opts.head.to_string(),
+                        base: opts.base.to_string(),
+                    })?,
                 Err(e) => {
                     self.append_slack_error(format!(
                         "Failed to get existing PR number for {owner}/{repo}: {e}"

--- a/src/github/tag.rs
+++ b/src/github/tag.rs
@@ -405,7 +405,10 @@ impl GithubClient {
                     "Failed to sync lightweight tags for {owner}/{repo}: {e}"
                 ))
                 .await;
-                return Err(GitError::Other("Failed to sync tag".to_string()));
+                return Err(GitError::SyncFailure {
+                    ref_type: String::from("lightweight tags"),
+                    repository: format!("{owner}/{repo}"),
+                });
             }
         }
         if !errors.is_empty() {
@@ -622,10 +625,9 @@ impl GithubClient {
                     ])
                     .status()?;
                 if !fetch_status.success() {
-                    return Err(GitError::Other(format!(
-                        "Failed to fetch annotated tag {} from ",
-                        tag.name,
-                    )));
+                    return Err(GitError::NoSuchTag(
+                        tag.name.to_string(),
+                    ));
                 }
                 if let Some(sha) = tag.commit_sha.as_ref() {
                     let output = Command::new("git")
@@ -639,6 +641,7 @@ impl GithubClient {
                         .output()?;
                     if !output.status.success() {
                         eprintln!("Commit {sha} does not exist in any configured remote.");
+                        return Err(GitError::NoSuchReference(sha.to_string()));
                     }
                     let branch_output = String::from_utf8_lossy(&output.stdout);
                     if !branch_output.contains("origin") {
@@ -664,9 +667,8 @@ impl GithubClient {
 
             let status = Command::new("git").args(&push_args).status()?;
             if !status.success() {
-                              return Err(GitError::Other(format!(
-                    "Failed to push annotated tags to {ssh_url}"
-                )));
+                              return Err(GitError::GitPushError(ssh_url.to_string()
+                ));
             }
             if slack_error.is_empty() {
                 Ok(None)
@@ -764,11 +766,19 @@ impl GithubClient {
             });
         }
 
+        let mut errors: Vec<(String, GitError)> = Vec::new();
+
         while let Some((repo, result)) = futures.next().await {
             match result {
                 Ok(()) => {}
-                Err(e) => eprintln!("Failed to create tag '{tag}' for '{repo}': {e}"),
+                Err(e) => {
+                    eprintln!("Failed to create tag '{tag}' for '{repo}': {e}");
+                    errors.push((repo.to_string(), e));
+                }
             }
+        }
+        if !errors.is_empty() {
+            return Err(GitError::MultipleErrors(errors));
         }
         Ok(())
     }
@@ -847,12 +857,18 @@ impl GithubClient {
                 (repo, result)
             });
         }
-
+        let mut errors: Vec<(String, GitError)> = Vec::new();
         while let Some((repo, result)) = futures.next().await {
             match result {
                 Ok(()) => {}
-                Err(e) => eprintln!("Failed to delete tag '{tag}' for {repo}: {e}"),
+                Err(e) => {
+                    eprintln!("Failed to delete tag '{tag}' for {repo}: {e}");
+                    errors.push((repo.to_string(), e));
+                }
             }
+        }
+        if !errors.is_empty() {
+            return Err(GitError::MultipleErrors(errors));
         }
         Ok(())
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -95,10 +95,7 @@ pub fn generate_config(path: Option<&PathBuf>, force: bool) -> Result<PathBuf, G
         }
         (Some(path), false, _) => {
             if path.exists() {
-                return Err(GitError::Other(format!(
-                    "Config file already exists at {}. Use --force to overwrite",
-                    path.display()
-                )));
+                return Err(GitError::FileExists(path.to_string_lossy().to_string()));
             }
             fs::write(path, SAMPLE_CONFIG)?;
             Ok(path.clone())
@@ -115,10 +112,9 @@ pub fn generate_config(path: Option<&PathBuf>, force: bool) -> Result<PathBuf, G
         (None, false, Some(config_path)) => {
             println!("{}", config_path.display());
             if config_path.exists() {
-                return Err(GitError::Other(format!(
-                    "Config file already exists at {}. Use --force to overwrite",
-                    config_path.display()
-                )));
+                return Err(GitError::FileExists(
+                    config_path.to_string_lossy().to_string(),
+                ));
             }
             fs::write(&config_path, SAMPLE_CONFIG)?;
             Ok(config_path)


### PR DESCRIPTION
This adds some more specific error types so that we can pass more usable information to a user when something goes wrong. This includes giving more suggestions of how to proceed.

This tries to remove many of the GitError::Other uses that provide little context, and that does not provide any steps to the user they can use to proceed.