### PR TITLE
ODP-5616: Add a cache for fetching branches/tags, update packages, improve performance for missing tags/branches

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,7 +1,7 @@
 [advisories]
 # These are both low severity vulnerabilities.
 # Safe to ignore
-ignore = ["RUSTSEC-2026-0098", "RUSTSEC-2026-0099"]
+ignore = ["RUSTSEC-2026-0098", "RUSTSEC-2026-0099", "RUSTSEC-2026-0104"]
 informational_warnings = ["unmaintained"]
 severity_threshold = "high"
 

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,7 @@
 [advisories]
-# These are both low severity vulnerabilities.
-# Safe to ignore
+# These three advisories are safe to ignore.
+# RUSTSEC-2026-0098 and RUSTSEC-2026-0099 are low severity vulnerabilities,
+# and RUSTSEC-2026-0104 is not applicable to this project.
 ignore = ["RUSTSEC-2026-0098", "RUSTSEC-2026-0099", "RUSTSEC-2026-0104"]
 informational_warnings = ["unmaintained"]
 severity_threshold = "high"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "git_sync"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "aws-config",
  "aws-lc-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.15"
+version = "1.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -167,7 +167,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.129.0"
+version = "1.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4e8410fadbc0ee453145dd77a4958227b18b05bf67c2795d0a8b8596c9aa0f"
+checksum = "fe1b8c5282bf859170836045296b3cd710b7573aceb909498366bb508a41058e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -261,23 +261,23 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.11.0",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.97.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.99.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -348,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -361,13 +361,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "p256",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.6"
+version = "0.64.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6750f3dd509b0694a4377f0293ed2f9630d710b1cebe281fa8bac8f099f88bc6"
+checksum = "10efbbcec1e044b81600e2fc562a391951d291152d95b482d5b7e7132299d762"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -401,8 +401,8 @@ dependencies = [
  "http-body-util",
  "md-5",
  "pin-project-lite",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "tracing",
 ]
 
@@ -460,7 +460,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -524,11 +524,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -537,6 +538,17 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -576,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -647,6 +659,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
  "serde_core",
@@ -704,26 +725,20 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -764,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -799,18 +814,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.2"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -842,6 +857,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "colorchoice"
@@ -876,6 +897,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -932,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
@@ -943,7 +970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rustversion",
  "spin",
 ]
@@ -996,6 +1023,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,7 +1060,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1034,9 +1079,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1083,7 +1140,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
  "der",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1150,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1404,13 +1461,13 @@ dependencies = [
  "microxdg",
  "octocrab",
  "reqwest",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "tabled",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tokio",
  "tokio-retry",
@@ -1517,7 +1574,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1586,6 +1652,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1657,7 +1732,7 @@ dependencies = [
  "hyper 1.9.0",
  "hyper-util",
  "log",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1827,9 +1902,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1891,9 +1966,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1904,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1915,27 +1990,32 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1969,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2004,9 +2084,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -2074,12 +2154,12 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2173,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.49.7"
+version = "0.49.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f6687a23731011d0117f9f4c3cdabaa7b5e42ca671f42b5cc0657c492540e3"
+checksum = "4ddbc3bb87e8c680febf16f56855bbd8b44a38e18c913334213ab34908e71a09"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2245,7 +2325,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2346,9 +2426,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -2430,9 +2510,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "socket2 0.6.3",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -2451,10 +2531,10 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2605,9 +2685,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2626,7 +2706,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -2650,7 +2730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -2716,15 +2796,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -2743,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2753,19 +2833,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2790,9 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2985,7 +3065,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2996,7 +3087,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3021,7 +3123,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3041,6 +3143,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,7 +3166,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -3263,31 +3381,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3359,9 +3457,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3411,7 +3509,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.38",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -3554,9 +3652,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -3633,9 +3731,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3690,11 +3788,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3703,14 +3801,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3721,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3731,9 +3829,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3741,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3754,9 +3852,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -3797,9 +3895,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3818,9 +3916,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3906,15 +4004,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3938,21 +4027,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3990,12 +4064,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4008,12 +4076,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4023,12 +4085,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4056,12 +4112,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4071,12 +4121,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4092,12 +4136,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4107,12 +4145,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4128,9 +4160,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -4140,6 +4172,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ version     = "1.0.10"
 
 
 [dependencies]
-aws-config = { features = ["rustls"], optional = true, version = "1.8.15" }
-aws-lc-rs  = "1.16.2"
-aws-sdk-s3 = { optional = true, version = "1.129" }
+aws-config = { features = ["rustls"], optional = true, version = "1.8.16" }
+aws-lc-rs  = "1.16.3"
+aws-sdk-s3 = { optional = true, version = "1.131" }
 # Override the 'bytes' library to fix a CVE
 bytes = "1.11.1"
 chrono = { features = ["clock", "iana-time-zone", "std"], version = "0.4" }
@@ -20,22 +20,22 @@ clap = { features = [
   "env",
   "unicode",
   "wrap_help",
-], version = "4.5.58" }
+], version = "4.6.1" }
 clap-verbosity-flag = "3.0.4"
-clap_complete = "4.5.66"
+clap_complete = "4.6.3"
 clap_mangen = "0.3.0"
-console = "0.16.1"
+console = "0.16.3"
 dashmap = "6.1.0"
-env_logger = "0.11.9"
-fancy-regex = "0.17"
-flate2 = { default-features = false, features = ["zlib-ng"], version = "1.1.2" }
-futures = { features = ["alloc", "async-await", "std"], version = "0.3.31" }
+env_logger = "0.11.10"
+fancy-regex = "0.18.0"
+flate2 = { default-features = false, features = ["zlib-ng"], version = "1.1.9" }
+futures = { features = ["alloc", "async-await", "std"], version = "0.3.32" }
 http = "1.4.0"
 http-body-util = "0.1.3"
-hyper = { default-features = false, version = "1.7.0" }
-iana-time-zone = "0.1"
-indexmap = { features = ["serde"], version = "2.11" }
-indicatif = { features = ["tokio"], version = "0.18.0" }
+hyper = { default-features = false, version = "1.9.0" }
+iana-time-zone = "0.1.65"
+indexmap = { features = ["serde"], version = "2.14.0" }
+indicatif = { features = ["tokio"], version = "0.18.4" }
 log = "0.4.29"
 microxdg = "0.2.0"
 octocrab = { default-features = false, features = [
@@ -48,15 +48,15 @@ octocrab = { default-features = false, features = [
   "stream",
   "timeout",
   "tokio",
-], version = "0.49.7" }
+], version = "0.49.9" }
 reqwest = { features = [
   "__tls",
   "charset",
   "http2",
   "json",
-], version = "0.13.2" }
-rustls = { features = ["aws_lc_rs"], version = "0.23.38" }
-serde = { features = ["derive"], version = "1.0" }
+], version = "0.13.3" }
+rustls = { features = ["aws_lc_rs"], version = "0.23.40" }
+serde = { features = ["derive"], version = "1.0.228" }
 serde_json = "1.0"
 tabled = { features = ["ansi", "macros", "std"], version = "0.20" }
 tar = "0.4.45"
@@ -64,9 +64,9 @@ tempfile = "3.25.0"
 thiserror = "2.0"
 # Time is not used directly, but it needs to be upgraded to fix a CVE
 time        = "0.3.47"
-tokio       = { features = ["macros", "rt-multi-thread"], version = "1.47" }
-tokio-retry = "0.3"
-toml        = "1.0"
+tokio       = { features = ["macros", "rt-multi-thread"], version = "1.52.1" }
+tokio-retry = "0.3.1"
+toml        = "1.1"
 #sqlx = { version = "0.8.6", optional = true, default-features = false, features = [
 #  "chrono",
 #  "derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition     = "2024"
 homepage    = "https://github.com/acceldata-io/git_sync"
 license     = "Apache-2.0"
 name        = "git_sync"
-version     = "1.0.9"
+version     = "1.0.10"
 
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -531,6 +531,15 @@ $ $ git_sync repo check --repository-type all --all --license --old-branches --d
 
 It will detect you are not running in an interactive terminal and will create a header, then output information in a comma separated format.
 
+## Cache
+
+This tool caches the branches and tags for repositories in order to speed up operations that would otherwise take quite a while, such as fetching tags from 40+ repositories. This cache file is by default stored in `~/.config/git-cache.json`, but can be changed at runtime.
+It has a few modifiable flags to manage different aspects of it:
+
+1. `--update-cache` - update the cache, even if it already exists.
+2. `--cache-file <path>` - path to your cache file. This only needs to be provided if you want to use a different path than the default.
+3. `--ttl <seconds>` - the length of time for which the cached values are valid. Anything that exceeds this time will be considered stale and removed from the cache. By default, this is set to 86,400 seconds (24h).
+
 ## Additional notes
 
 - You will need a Github Token with both the 'repo' scope and the 'workflow' scope enabled, if using a classic token. Without these, syncing repositories may not work correctly.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -17,11 +17,4 @@ specific language governing permissions and limitations
 under the License.
 */
 
-pub mod cache;
-pub mod cli;
-pub mod config;
-pub mod error;
-pub mod github;
-pub mod init;
-pub mod slack;
-pub mod utils;
+pub mod store;

--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -1,0 +1,390 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+use crate::error::CacheError;
+use crate::utils::repo::TagInfo;
+use chrono::{DateTime, Utc};
+use indexmap::IndexSet;
+use log::debug;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct TagData {
+    pub tags: IndexSet<TagInfo>,
+    pub parent_urls: HashSet<String>,
+}
+
+type BranchCache = HashMap<String, CacheEntry<HashMap<String, String>>>;
+type TagCache = HashMap<String, CacheEntry<TagData>>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CacheEntry<T: Clone> {
+    pub data: T,
+    pub fetched_at: DateTime<Utc>,
+}
+
+impl<T: Clone> CacheEntry<T> {
+    fn is_stale(&self, ttl: Duration) -> bool {
+        let age = Utc::now() - self.fetched_at;
+        age.to_std().map(|a| a > ttl).unwrap_or(true)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct DiskCache {
+    branches: BranchCache,
+    tags: TagCache,
+}
+
+#[derive(Debug)]
+pub struct Cache {
+    data: RwLock<DiskCache>,
+    path: PathBuf,
+    ttl: Duration,
+    update: bool,
+}
+
+impl Cache {
+    pub fn new(path: PathBuf, ttl: Duration, update: bool) -> Self {
+        Self {
+            data: RwLock::new(DiskCache::default()),
+            path,
+            ttl,
+            update,
+        }
+    }
+
+    pub fn from(path: &Path, ttl: Duration, update: bool) -> Result<Self, CacheError> {
+        debug!("Loading cache from {}", path.display());
+        let data = if path.exists() {
+            let bytes = std::fs::read(path)?;
+            serde_json::from_slice(&bytes)?
+        } else {
+            DiskCache::default()
+        };
+        if update {
+            eprintln!("Cache will be updated this run");
+        }
+        Ok(Self {
+            data: RwLock::new(data),
+            path: path.to_owned(),
+            ttl,
+            update,
+        })
+    }
+
+    pub fn get_branches(&self, key: &str) -> Option<HashMap<String, String>> {
+        if self.update {
+            return None;
+        }
+        let data = match self.data.read() {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Warning: Failed to acquire read lock on cache: {}", e);
+                return None;
+            }
+        };
+        data.branches
+            .get(key)
+            .filter(|e| !e.is_stale(self.ttl))
+            .map(|e| e.data.clone())
+    }
+    pub fn get_tags(&self, key: &str) -> Option<(IndexSet<TagInfo>, HashSet<String>)> {
+        if self.update {
+            return None;
+        }
+        let data = match self.data.read() {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Warning: Failed to acquire read lock on cache: {}", e);
+                return None;
+            }
+        };
+        data.tags
+            .get(key)
+            .filter(|e| !e.is_stale(self.ttl))
+            .map(|e| (e.data.tags.clone(), e.data.parent_urls.clone()))
+    }
+    pub fn set_branches(
+        &self,
+        key: impl AsRef<str>,
+        data: HashMap<String, String>,
+    ) -> Result<(), CacheError> {
+        let entry = CacheEntry {
+            data,
+            fetched_at: Utc::now(),
+        };
+        let mut data = match self.data.write() {
+            Ok(d) => d,
+            Err(e) => return Err(CacheError::LockError(e.to_string())),
+        };
+        data.branches.insert(key.as_ref().to_string(), entry);
+
+        Ok(())
+    }
+
+    pub fn remove_branch(
+        &self,
+        owner: &str,
+        repository: &str,
+        branch: &str,
+    ) -> Result<(), CacheError> {
+        let key = format!("{}/{}", owner, repository);
+        let mut data = match self.data.write() {
+            Ok(d) => d,
+            Err(e) => return Err(CacheError::LockError(e.to_string())),
+        };
+
+        if let Some(entry) = data.branches.get_mut(&key) {
+            entry.data.remove(branch);
+        }
+
+        Ok(())
+    }
+
+    pub fn set_tags(
+        &self,
+        key: impl ToString,
+        data: (IndexSet<TagInfo>, HashSet<String>),
+    ) -> Result<(), CacheError> {
+        debug!("Writing tags to cache for {}", key.to_string());
+        let entry = CacheEntry {
+            data: TagData {
+                tags: data.0,
+                parent_urls: data.1,
+            },
+            fetched_at: Utc::now(),
+        };
+        let mut data = match self.data.write() {
+            Ok(d) => d,
+            Err(e) => return Err(CacheError::LockError(e.to_string())),
+        };
+        data.tags.insert(key.to_string(), entry);
+        Ok(())
+    }
+
+    pub fn remove_tag(&self, owner: &str, repository: &str, tag: &str) -> Result<(), CacheError> {
+        let key = format!("{}/{}", owner, repository);
+        let mut data = match self.data.write() {
+            Ok(d) => d,
+            Err(e) => return Err(CacheError::LockError(e.to_string())),
+        };
+
+        if let Some(entry) = data.tags.get_mut(&key)
+            && let Some(pos) = entry.data.tags.iter().position(|t| t.name == tag)
+        {
+            entry.data.tags.shift_remove_index(pos);
+        }
+        Ok(())
+    }
+
+    fn write_to_disk(&self) -> Result<(), CacheError> {
+        let data = self
+            .data
+            .read()
+            .map_err(|e| CacheError::LockError(e.to_string()))?;
+
+        let mut branches = data.branches.clone();
+        let mut tags = data.tags.clone();
+        drop(data);
+
+        branches.retain(|_, e| !e.is_stale(self.ttl));
+        tags.retain(|_, e| !e.is_stale(self.ttl));
+        let pruned = DiskCache { branches, tags };
+
+        let bytes = serde_json::to_vec_pretty(&pruned)?;
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&self.path, &bytes)?;
+        Ok(())
+    }
+}
+
+impl Drop for Cache {
+    fn drop(&mut self) {
+        if let Err(e) = self.write_to_disk() {
+            eprintln!("Warning: failed to persist cache: {e}");
+        } else {
+            debug!("Cache written to {}", self.path.display());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::repo::TagType;
+    use indexmap::IndexSet;
+    use std::collections::{HashMap, HashSet};
+    use std::path::PathBuf;
+    use std::sync::RwLock;
+    use std::time::Duration;
+
+    // Helper functions for tests
+
+    fn make_cache(ttl_secs: u64) -> Cache {
+        Cache {
+            data: RwLock::new(DiskCache::default()),
+            path: PathBuf::from("/tmp/git_sync_unit_test_never_written.json"),
+            ttl: Duration::from_secs(ttl_secs),
+            update: false,
+        }
+    }
+
+    fn stale_entry<T: Clone>(data: T, age_secs: u64) -> CacheEntry<T> {
+        CacheEntry {
+            data,
+            fetched_at: Utc::now() - Duration::from_secs(age_secs),
+        }
+    }
+
+    fn sample_branches() -> HashMap<String, String> {
+        HashMap::from([
+            ("main".to_string(), "2026-01-01T00:00:00Z".to_string()),
+            ("develop".to_string(), "2026-01-02T00:00:00Z".to_string()),
+        ])
+    }
+
+    fn sample_tag(name: &str) -> TagInfo {
+        TagInfo {
+            name: name.to_string(),
+            tag_type: TagType::Lightweight,
+            sha: "abc123".to_string(),
+            url: "https://github.com/owner/repo".to_string(),
+            commit_sha: None,
+        }
+    }
+
+    fn sample_tag_data() -> TagData {
+        let mut tags = IndexSet::new();
+        tags.insert(sample_tag("v1.0"));
+        tags.insert(sample_tag("v2.0"));
+        TagData {
+            tags,
+            parent_urls: HashSet::new(),
+        }
+    }
+
+    // Actual tests
+
+    #[test]
+    fn branch_entry_is_returned() {
+        let cache = make_cache(3600);
+        cache.set_branches("owner/repo", sample_branches()).unwrap();
+        let result = cache.get_branches("owner/repo");
+        assert!(result.is_some());
+        let branches = result.unwrap();
+        assert_eq!(branches.len(), 2);
+        assert!(branches.contains_key("main"));
+    }
+
+    #[test]
+    fn stale_branch_entry_is_not_returned() {
+        let cache = make_cache(3600);
+        // Insert entry that is greater than one hour old
+        let entry = stale_entry(sample_branches(), 7200);
+        cache
+            .data
+            .write()
+            .unwrap()
+            .branches
+            .insert("owner/repo".to_string(), entry);
+
+        let result = cache.get_branches("owner/repo");
+        assert!(result.is_none(), "Stale entry should not be returned");
+    }
+
+    #[test]
+    fn missing_branch_key_returns_none() {
+        let cache = make_cache(3600);
+        assert!(cache.get_branches("owner/nonexistent").is_none());
+    }
+
+    #[test]
+    fn tag_entry_returned() {
+        let cache = make_cache(3600);
+        let (tags, parents) = (sample_tag_data().tags, sample_tag_data().parent_urls);
+        cache.set_tags("owner/repo", (tags, parents)).unwrap();
+        let result = cache.get_tags("owner/repo");
+        assert!(result.is_some());
+        let (tags, _) = result.unwrap();
+        assert_eq!(tags.len(), 2);
+    }
+
+    #[test]
+    fn stale_tag_entry_not_returned() {
+        let cache = make_cache(3600);
+        let entry = stale_entry(sample_tag_data(), 7200);
+        cache
+            .data
+            .write()
+            .unwrap()
+            .tags
+            .insert("owner/repo".to_string(), entry);
+
+        assert!(
+            cache.get_tags("owner/repo").is_none(),
+            "Stale entry should not be returned"
+        );
+    }
+    #[test]
+    fn remove_tag_removes_specific_tag() {
+        let cache = make_cache(3600);
+        let data = sample_tag_data();
+        cache
+            .set_tags("owner/repo", (data.tags, data.parent_urls))
+            .unwrap();
+
+        cache.remove_tag("owner", "repo", "v1.0").unwrap();
+
+        let (tags, _) = cache.get_tags("owner/repo").unwrap();
+        assert!(
+            !tags.iter().any(|t| t.name == "v1.0"),
+            "'v1.0' should be removed"
+        );
+        assert!(tags.iter().any(|t| t.name == "v2.0"), "'v2.0' should exist");
+    }
+
+    #[test]
+    fn remove_tag_noop_when_tag_not_in_cache() {
+        let cache = make_cache(3600);
+        let data = sample_tag_data();
+        cache
+            .set_tags("owner/repo", (data.tags, data.parent_urls))
+            .unwrap();
+
+        let result = cache.remove_tag("owner", "repo", "v99.0");
+        assert!(result.is_ok());
+
+        let (tags, _) = cache.get_tags("owner/repo").unwrap();
+        assert_eq!(tags.len(), 2, "Tag count should be unchanged");
+    }
+
+    #[test]
+    fn remove_tag_noop_when_repo_not_in_cache() {
+        let cache = make_cache(3600);
+        let result = cache.remove_tag("owner", "missing", "v1.0");
+        assert!(result.is_ok());
+    }
+}

--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -239,14 +239,46 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::path::PathBuf;
     use std::sync::RwLock;
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     // Helper functions for tests
+    struct TempCacheFile(PathBuf);
+
+    impl TempCacheFile {
+        fn new(ttl_secs: u64) -> (Cache, Self) {
+            let path = unique_test_cache_path();
+            let cache = Cache {
+                data: RwLock::new(DiskCache::default()),
+                path: path.clone(),
+                ttl: Duration::from_secs(ttl_secs),
+                update: false,
+            };
+            (cache, TempCacheFile(path))
+        }
+    }
+
+    impl Drop for TempCacheFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0); // ignore error if file was never written
+        }
+    }
+
+    fn unique_test_cache_path() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after UNIX_EPOCH")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "git_sync_unit_test_{}_{}.json",
+            std::process::id(),
+            nanos
+        ))
+    }
 
     fn make_cache(ttl_secs: u64) -> Cache {
         Cache {
             data: RwLock::new(DiskCache::default()),
-            path: PathBuf::from("/tmp/git_sync_unit_test_never_written.json"),
+            path: unique_test_cache_path(),
             ttl: Duration::from_secs(ttl_secs),
             update: false,
         }
@@ -301,7 +333,7 @@ mod tests {
 
     #[test]
     fn stale_branch_entry_is_not_returned() {
-        let cache = make_cache(3600);
+        let (cache, _guard) = TempCacheFile::new(3600);
         // Insert entry that is greater than one hour old
         let entry = stale_entry(sample_branches(), 7200);
         cache
@@ -317,13 +349,13 @@ mod tests {
 
     #[test]
     fn missing_branch_key_returns_none() {
-        let cache = make_cache(3600);
+        let (cache, _guard) = TempCacheFile::new(3600);
         assert!(cache.get_branches("owner/nonexistent").is_none());
     }
 
     #[test]
     fn tag_entry_returned() {
-        let cache = make_cache(3600);
+        let (cache, _guard) = TempCacheFile::new(3600);
         let (tags, parents) = (sample_tag_data().tags, sample_tag_data().parent_urls);
         cache.set_tags("owner/repo", (tags, parents)).unwrap();
         let result = cache.get_tags("owner/repo");
@@ -334,7 +366,7 @@ mod tests {
 
     #[test]
     fn stale_tag_entry_not_returned() {
-        let cache = make_cache(3600);
+        let (cache, _guard) = TempCacheFile::new(3600);
         let entry = stale_entry(sample_tag_data(), 7200);
         cache
             .data
@@ -350,7 +382,7 @@ mod tests {
     }
     #[test]
     fn remove_tag_removes_specific_tag() {
-        let cache = make_cache(3600);
+        let (cache, _guard) = TempCacheFile::new(3600);
         let data = sample_tag_data();
         cache
             .set_tags("owner/repo", (data.tags, data.parent_urls))
@@ -368,7 +400,7 @@ mod tests {
 
     #[test]
     fn remove_tag_noop_when_tag_not_in_cache() {
-        let cache = make_cache(3600);
+        let (cache, _guard) = TempCacheFile::new(3600);
         let data = sample_tag_data();
         cache
             .set_tags("owner/repo", (data.tags, data.parent_urls))
@@ -383,7 +415,7 @@ mod tests {
 
     #[test]
     fn remove_tag_noop_when_repo_not_in_cache() {
-        let cache = make_cache(3600);
+        let (cache, _guard) = TempCacheFile::new(3600);
         let result = cache.remove_tag("owner", "missing", "v1.0");
         assert!(result.is_ok());
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,8 +82,8 @@ pub struct AppArgs {
     pub dry_run: bool,
 
     /// Force update the cache for repositories
-    #[arg(short, long, global = true, default_value_t = false)]
-    pub update: bool,
+    #[arg(long, global = true, default_value_t = false)]
+    pub update_cache: bool,
 
     /// Set the cache ttl in seconds. Default is 24 hours (60 * 60 * 24).
     /// See `update` for force updating the cache

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -81,10 +81,38 @@ pub struct AppArgs {
     #[arg(long, global = true, default_value_t = false)]
     pub dry_run: bool,
 
+    /// Force update the cache for repositories
+    #[arg(short, long, global = true, default_value_t = false)]
+    pub update: bool,
+
+    /// Set the cache ttl in seconds. Default is 24 hours (60 * 60 * 24).
+    /// See `update` for force updating the cache
+    #[arg(long, global = true, default_value_t = 86_400)]
+    pub ttl: u64,
+
+    /// The cache file used for tags and branches
+    #[arg(
+        long,
+        global = true,
+        env = "CACHE_FILE",
+        default_value = "~/.config/git-cache.json",
+        value_parser = expand_tilde,
+    )]
+    pub cache_file: PathBuf,
+
     /// Override the slack webhook url from the config file
     #[cfg(feature = "slack")]
     #[arg(long, global = true, env = "SLACK_WEBHOOK")]
     pub slack_webhook: Option<String>,
+}
+
+fn expand_tilde(path: &str) -> Result<PathBuf, String> {
+    if let Some(stripped) = path.strip_prefix("~/") {
+        let home = std::env::var("HOME").map_err(|_| "Could not determine $HOME".to_string())?;
+        Ok(PathBuf::from(home).join(stripped))
+    } else {
+        Ok(PathBuf::from(path))
+    }
 }
 
 /// Validate that the maximum number of parallel jobs is between 1 and 64.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,7 +86,7 @@ pub struct AppArgs {
     pub update_cache: bool,
 
     /// Set the cache ttl in seconds. Default is 24 hours (60 * 60 * 24).
-    /// See `update` for force updating the cache
+    /// See the `update-cache` flag for force updating the cache
     #[arg(long, global = true, default_value_t = 86_400)]
     pub ttl: u64,
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,12 +29,8 @@ use thiserror::Error;
 pub enum CacheError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("Failed to deserialize cache: {0}")]
-    Deserialize(#[from] serde_json::Error),
-    // You need to map this error for it to work.
-    // Ex: serde_json::to_vec_pretty(&*inner).map_err(CacheError::Serialize)?;
-    #[error("Failed to serialize cache: {0}")]
-    Serialize(serde_json::Error),
+    #[error("Failed to serialize/deserialize Json for cache: {0}")]
+    JsonError(#[from] serde_json::Error),
     #[error("Cache entry invalid for {key}: {reason}")]
     Invalid { key: String, reason: String },
     #[error("Lock Error: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,22 @@ use std::io::ErrorKind::{
 };
 use thiserror::Error;
 
+#[derive(Error, Debug)]
+pub enum CacheError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Failed to deserialize cache: {0}")]
+    Deserialize(#[from] serde_json::Error),
+    // You need to map this error for it to work.
+    // Ex: serde_json::to_vec_pretty(&*inner).map_err(CacheError::Serialize)?;
+    #[error("Failed to serialize cache: {0}")]
+    Serialize(serde_json::Error),
+    #[error("Cache entry invalid for {key}: {reason}")]
+    Invalid { key: String, reason: String },
+    #[error("Lock Error: {0}")]
+    LockError(String),
+}
+
 /// Error type to make it easier to handle returning from functions
 #[derive(Error, Debug)]
 pub enum GitError {
@@ -202,6 +218,10 @@ pub enum GitError {
         /// Group Name
         String,
     ),
+    /// An error with the cache
+    #[error("Cache error: {0}")]
+    Cache(#[from] CacheError),
+
     /// Unclassified error
     #[error("{0}")]
     Other(
@@ -415,7 +435,11 @@ impl GitError {
                 message: format!("Semaphore Error: {e}"),
                 suggestion: None,
             },
-
+            GitError::Cache(e) => UserError {
+                code: None,
+                message: format!("Cache error: {e}"),
+                suggestion: Some("Check your cache file/folder and permissions.".into()),
+            },
             GitError::Other(msg) => UserError {
                 code: None,
                 message: msg.clone(),

--- a/src/github/branch.rs
+++ b/src/github/branch.rs
@@ -609,7 +609,7 @@ impl GithubClient {
             return Ok(branches.contains_key(branch.as_ref()));
         }
 
-        let res = async_retry(100, 5000, 3, GitError::is_retryable, || {
+        async_retry(100, 5000, 3, GitError::is_retryable, || {
             let owner = owner.clone();
             let repo = repository.clone();
             let branch = branch.as_ref().to_string();
@@ -630,9 +630,7 @@ impl GithubClient {
                 }
             }
         })
-        .await?;
-
-        Ok(res)
+        .await
     }
     /// Check to see if a branch is *not* present, in all passed repositories
     pub async fn is_branch_present_all<T, U>(

--- a/src/github/branch.rs
+++ b/src/github/branch.rs
@@ -588,17 +588,12 @@ impl GithubClient {
     {
         let info = get_repo_info_from_url(url.as_ref())?;
         let (owner, repo) = (info.owner, info.repo_name);
-        let all_branches: Vec<String> = self
-            .fetch_branches(owner, repo)
-            .await?
-            .keys()
-            .cloned()
-            .collect();
+        let all_branches = self.fetch_branches(owner, repo).await?;
         debug!(
             "Finished filtering. Available permits are now: {}",
             self.semaphore.available_permits()
         );
-        filter_ref(&all_branches, &filter)
+        filter_ref(all_branches.keys().map(|s| s.as_str()), &filter)
     }
     /// Check to see if a branch is present in a repository
     pub async fn is_branch_present<T, U>(&self, url: T, branch: U) -> Result<bool, GitError>
@@ -608,13 +603,36 @@ impl GithubClient {
     {
         let info = get_repo_info_from_url(&url)?;
         let (owner, repository) = (info.owner, info.repo_name);
-        let branches: Vec<String> = self
-            .fetch_branches(owner, repository)
-            .await?
-            .keys()
-            .cloned()
-            .collect();
-        Ok(branches.iter().any(|b| b == branch.as_ref()))
+        let key = format!("{}/{}", owner, repository);
+        if let Some(branches) = self.cache.get_branches(&key) {
+            debug!("Cache hit for branches in {key}");
+            return Ok(branches.contains_key(branch.as_ref()));
+        }
+
+        let res = async_retry(100, 5000, 3, GitError::is_retryable, || {
+            let owner = owner.clone();
+            let repo = repository.clone();
+            let branch = branch.as_ref().to_string();
+            async move {
+                let _permit = self.semaphore.clone().acquire_owned().await?;
+                match self
+                    .octocrab
+                    .clone()
+                    .repos(owner, repo)
+                    .get_ref(&Reference::Branch(branch))
+                    .await
+                {
+                    Ok(_) => Ok(true),
+                    Err(octocrab::Error::GitHub { source, .. }) if source.status_code == 404 => {
+                        Ok(false)
+                    }
+                    Err(e) => Err(GitError::GithubApiError(e)),
+                }
+            }
+        })
+        .await?;
+
+        Ok(res)
     }
     /// Check to see if a branch is *not* present, in all passed repositories
     pub async fn is_branch_present_all<T, U>(

--- a/src/github/check.rs
+++ b/src/github/check.rs
@@ -122,8 +122,8 @@ impl GithubClient {
                 body = { octocrab.graphql(&payload).await },
             )?;
             drop(permit);
-            let refs = &response["data"]["repository"]["refs"];
-            license = response["data"]["repository"]["licenseInfo"]
+            let refs = &response["repository"]["refs"];
+            license = response["repository"]["licenseInfo"]
                 .as_object()
                 .and_then(|license| {
                     serde_json::from_value::<LicenseInfo>(serde_json::Value::Object(
@@ -160,7 +160,7 @@ impl GithubClient {
                 }
             }
             if let Some(protection) =
-                response["data"]["repository"]["branchProtectionRules"]["nodes"].as_array()
+                response["repository"]["branchProtectionRules"]["nodes"].as_array()
             {
                 for rule in protection {
                     let parsed_rule: Option<BranchProtectionRule> =
@@ -214,8 +214,11 @@ impl GithubClient {
         license: Option<&LicenseInfo>,
         repo: &str,
     ) {
+        if rows.is_empty() && self.is_tty {
+            println!("No results for {repo}");
+            return;
+        }
         if self.is_tty {
-            println!("TTY?");
             let table = Table::builder(tabled::settings::style::Style::ascii())
                 .title(format!("Stale Branches for {repo}"))
                 .header(header)

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -210,7 +210,7 @@ impl GithubClient {
 
         match response {
             Ok(resp) => {
-                let rate_limit = &resp["data"]["rateLimit"];
+                let rate_limit = &resp["rateLimit"];
                 let limit = rate_limit["limit"].as_u64().unwrap_or(0);
                 let remaining = rate_limit["remaining"].as_u64().unwrap_or(0);
                 let reset_at_str = rate_limit["resetAt"].as_str().unwrap_or("");

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -17,11 +17,13 @@ specific language governing permissions and limitations
 under the License.
 */
 use crate::async_retry;
+use crate::cache::store::Cache;
 use crate::config::Config;
 use crate::error::{GitError, is_retryable};
 use crate::utils::repo::{RepoInfo, TagInfo, get_repo_info_from_url};
 use chrono::{DateTime, Local, TimeZone, Utc};
 use octocrab::Octocrab;
+use std::time::Duration;
 use tokio::sync::Mutex;
 
 use indexmap::IndexSet;
@@ -30,6 +32,7 @@ use tokio::sync::Semaphore;
 use std::collections::HashSet;
 use std::fmt::Write as _;
 use std::io::IsTerminal;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 
@@ -55,6 +58,8 @@ pub struct GithubClient {
     pub is_tty: bool,
     /// Where output should go. This can only be written to Once
     pub output: Arc<OnceCell<OutputMode>>,
+    /// A cache for storing branches/tags for faster access
+    pub cache: Cache,
     /// A message that gets sent to slack at the end of all processing, if it has any contents.
     /// This is thread safe.
     slack_messages: Arc<Mutex<Vec<String>>>,
@@ -86,12 +91,21 @@ impl GithubClient {
         _config: &Config,
         max_jobs: usize,
         slack_webhook: Option<String>,
+        cache_file: PathBuf,
+        cache_ttl: u64,
+        cache_update: bool,
     ) -> Result<Self, GitError> {
         let octocrab = Octocrab::builder()
             .personal_token(github_token.as_ref())
             .build()
             .map_err(GitError::GithubApiError)?;
         let webhook_url: String = slack_webhook.unwrap_or_default().trim().to_string();
+        let cache =
+            if let Ok(c) = Cache::from(&cache_file, Duration::from_secs(cache_ttl), cache_update) {
+                c
+            } else {
+                Cache::new(cache_file, Duration::from_secs(cache_ttl), cache_update)
+            };
 
         Ok(Self {
             octocrab,
@@ -101,6 +115,7 @@ impl GithubClient {
             // This is a type that can only be written to once, and represents the type of output
             // that we have.
             output: Arc::new(OnceCell::new()),
+            cache,
             // Arbitrary initial capacity to avoid allocations if there aren't that many messages
             slack_messages: Arc::new(Mutex::new(Vec::with_capacity(100))),
             slack_errors: Arc::new(Mutex::new(Vec::with_capacity(100))),

--- a/src/github/fork.rs
+++ b/src/github/fork.rs
@@ -89,10 +89,6 @@ struct RepositoryData {
 struct RepoRefs {
     refs: BranchConnection,
 }
-#[derive(Debug, Deserialize)]
-struct BranchCommits {
-    data: RepositoryData,
-}
 
 impl GithubClient {
     /// Sync a single repository with its parent repository. Optionally, specify a branch to sync.
@@ -171,7 +167,7 @@ impl GithubClient {
                 },
             });
 
-            let res: BranchCommits = async_retry!(
+            let res: RepositoryData = async_retry!(
                 ms = 100,
                 timeout = 5000,
                 retries = 3,
@@ -182,12 +178,12 @@ impl GithubClient {
                 },
             )?;
 
-            res.data.repository.refs.nodes.iter().for_each(|node| {
+            res.repository.refs.nodes.iter().for_each(|node| {
                 branches.insert(node.name.clone(), node.target.committed_date.clone());
             });
 
-            has_next_page = res.data.repository.refs.page_info.has_next_page;
-            cursor = res.data.repository.refs.page_info.end_cursor;
+            has_next_page = res.repository.refs.page_info.has_next_page;
+            cursor = res.repository.refs.page_info.end_cursor;
         }
 
         self.cache

--- a/src/github/fork.rs
+++ b/src/github/fork.rs
@@ -23,6 +23,7 @@ use crate::utils::repo::{get_repo_info_from_url, http_to_ssh_repo};
 use crate::{async_retry, handle_api_response};
 use chrono::DateTime;
 use futures::{StreamExt, stream::FuturesUnordered};
+use log::debug;
 use octocrab::params::repos::Reference;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -153,6 +154,13 @@ impl GithubClient {
         let mut cursor: Option<String> = None;
         let octocrab = self.octocrab.clone();
 
+        let key = format!("{}/{}", owner.as_ref(), repository.as_ref());
+
+        if let Some(cached) = self.cache.get_branches(&key) {
+            debug!("Cache hit for branches in {key}");
+            return Ok(cached);
+        }
+
         while has_next_page {
             let payload = serde_json::json!({
                 "query": GRAPHQL_QUERY,
@@ -181,6 +189,10 @@ impl GithubClient {
             has_next_page = res.data.repository.refs.page_info.has_next_page;
             cursor = res.data.repository.refs.page_info.end_cursor;
         }
+
+        self.cache
+            .set_branches(&key, branches.clone())
+            .unwrap_or_else(|e| eprintln!("Failed to cache branches for {key}: {e}"));
 
         Ok(branches)
     }

--- a/src/github/match_args.rs
+++ b/src/github/match_args.rs
@@ -117,7 +117,7 @@ pub async fn match_arguments(app: &AppArgs, config: Config) -> Result<(), GitErr
 
     let cache_file = app.cache_file.to_owned();
     let cache_ttl = app.ttl;
-    let cache_update = app.update;
+    let cache_update = app.update_cache;
 
     let client = GithubClient::new(
         &token,

--- a/src/github/match_args.rs
+++ b/src/github/match_args.rs
@@ -115,7 +115,19 @@ pub async fn match_arguments(app: &AppArgs, config: Config) -> Result<(), GitErr
     // This value must be greater than 0
     let jobs: usize = app.jobs.unwrap_or(default_jobs);
 
-    let client = GithubClient::new(&token, &config, jobs, slack_webhook)?;
+    let cache_file = app.cache_file.to_owned();
+    let cache_ttl = app.ttl;
+    let cache_update = app.update;
+
+    let client = GithubClient::new(
+        &token,
+        &config,
+        jobs,
+        slack_webhook,
+        cache_file,
+        cache_ttl,
+        cache_update,
+    )?;
     if !token.is_empty() && verbose {
         let (rest_limit, graphql_limit) =
             tokio::join!(client.get_rate_limit(), client.get_graphql_limit());

--- a/src/github/tag.rs
+++ b/src/github/tag.rs
@@ -20,7 +20,9 @@ under the License.
 use crate::error::{GitError, is_retryable};
 use crate::github::client::Comparison;
 use crate::utils::filter::filter_ref;
-use crate::utils::repo::{RepoInfo, TagInfo, TagType, get_repo_info_from_url, http_to_ssh_repo};
+use crate::utils::repo::{
+    RepoInfo, TagInfo, TagType, async_retry, get_repo_info_from_url, http_to_ssh_repo,
+};
 use crate::{async_retry, handle_api_response, handle_futures_unordered};
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt, future::try_join};
@@ -111,6 +113,15 @@ impl GithubClient {
     ) -> Result<(IndexSet<TagInfo>, HashSet<String>), GitError> {
         let info = get_repo_info_from_url(&url)?;
         let (owner, repo) = (info.owner, info.repo_name);
+
+        let key = format!("{}/{}", owner, repo);
+
+        if let Some(cached) = self.cache.get_tags(&key) {
+            debug!("Cache hit for tags in {key}");
+            return Ok(cached);
+        } else {
+            debug!("No cache found for {key}");
+        }
 
         let mut all_tags: IndexSet<TagInfo> = IndexSet::new();
         let mut has_next_page = true;
@@ -208,6 +219,8 @@ impl GithubClient {
             has_next_page = repo.refs.page_info.has_next_page;
             after = repo.refs.page_info.end_cursor;
         }
+        self.cache
+            .set_tags(&key, (all_tags.clone(), parent_urls.clone()))?;
 
         Ok((all_tags, parent_urls))
     }
@@ -924,20 +937,57 @@ impl GithubClient {
         U: AsRef<str> + Display,
     {
         let (all_tags, _) = self.get_tags(url).await?;
-        let tag_names_only: Vec<String> = all_tags.into_iter().map(|t| t.name.clone()).collect();
-        let filtered: Vec<String> = filter_ref(&tag_names_only, filter)?;
-        Ok(filtered)
+        filter_ref(all_tags.iter().map(|t| t.name.as_str()), filter)
     }
 
     /// Check to see if a tag is present in a repository
-    pub async fn is_tag_present<T, U>(&self, url: T, tag: U) -> Result<bool, GitError>
+    /*pub async fn is_tag_present<T, U>(&self, url: T, tag: U) -> Result<bool, GitError>
     where
         T: AsRef<str>,
         U: AsRef<str> + Display,
     {
         let (all_tags, _) = self.get_tags(url).await?;
-        let is_present = all_tags.iter().any(|t| t.name == tag.as_ref());
-        Ok(is_present)
+        Ok(all_tags.iter().any(|t| t.name == tag.as_ref()))
+    }
+    */
+    /// Check to see if a branch is present in a repository
+    pub async fn is_tag_present<T, U>(&self, url: T, tag: U) -> Result<bool, GitError>
+    where
+        T: AsRef<str> + Display,
+        U: AsRef<str> + Display,
+    {
+        let info = get_repo_info_from_url(&url)?;
+        let (owner, repository) = (info.owner, info.repo_name);
+        let key = format!("{}/{}", owner, repository);
+        if let Some((tags, _)) = self.cache.get_tags(&key) {
+            debug!("Cache hit for branches in {key}");
+            return Ok(tags.iter().any(|t| t.name == tag.as_ref()));
+        }
+
+        let res = async_retry(100, 5000, 3, GitError::is_retryable, || {
+            let owner = owner.clone();
+            let repo = repository.clone();
+            let tag = tag.as_ref().to_string();
+            async move {
+                let _permit = self.semaphore.clone().acquire_owned().await?;
+                match self
+                    .octocrab
+                    .clone()
+                    .repos(owner, repo)
+                    .get_ref(&Reference::Tag(tag))
+                    .await
+                {
+                    Ok(_) => Ok(true),
+                    Err(octocrab::Error::GitHub { source, .. }) if source.status_code == 404 => {
+                        Ok(false)
+                    }
+                    Err(e) => Err(GitError::GithubApiError(e)),
+                }
+            }
+        })
+        .await?;
+
+        Ok(res)
     }
 
     /// Filter tags for all configured repositories

--- a/src/github/tag.rs
+++ b/src/github/tag.rs
@@ -47,11 +47,6 @@ use std::fmt::{Display, Write as _};
 use crate::github::client::GithubClient;
 use http_body_util::BodyExt;
 
-/// The root level response from github
-#[derive(Deserialize)]
-pub struct RepoResponse {
-    pub data: RepoData,
-}
 /// Struct to deserialize the repository data into
 #[derive(Deserialize)]
 pub struct RepoData {
@@ -177,7 +172,7 @@ impl GithubClient {
                     "after": after,
                 }
             });
-            let res: RepoResponse = async_retry!(
+            let res: RepoData = async_retry!(
                 ms = 100,
                 timeout = 5000,
                 retries = 3,
@@ -188,7 +183,7 @@ impl GithubClient {
             // Drop the lock on the semaphore so other network activities can potentially run
             drop(permit);
 
-            let repo = res.data.repository;
+            let repo = res.repository;
 
             let parent_url = repo.parent.as_ref().map(|p| p.url.clone());
 

--- a/src/github/tag.rs
+++ b/src/github/tag.rs
@@ -964,7 +964,7 @@ impl GithubClient {
             return Ok(tags.iter().any(|t| t.name == tag.as_ref()));
         }
 
-        let res = async_retry(100, 5000, 3, GitError::is_retryable, || {
+        async_retry(100, 5000, 3, GitError::is_retryable, || {
             let owner = owner.clone();
             let repo = repository.clone();
             let tag = tag.as_ref().to_string();
@@ -985,9 +985,7 @@ impl GithubClient {
                 }
             }
         })
-        .await?;
-
-        Ok(res)
+        .await
     }
 
     /// Filter tags for all configured repositories

--- a/src/github/tag.rs
+++ b/src/github/tag.rs
@@ -936,16 +936,6 @@ impl GithubClient {
     }
 
     /// Check to see if a tag is present in a repository
-    /*pub async fn is_tag_present<T, U>(&self, url: T, tag: U) -> Result<bool, GitError>
-    where
-        T: AsRef<str>,
-        U: AsRef<str> + Display,
-    {
-        let (all_tags, _) = self.get_tags(url).await?;
-        Ok(all_tags.iter().any(|t| t.name == tag.as_ref()))
-    }
-    */
-    /// Check to see if a branch is present in a repository
     pub async fn is_tag_present<T, U>(&self, url: T, tag: U) -> Result<bool, GitError>
     where
         T: AsRef<str> + Display,

--- a/src/utils/repo.rs
+++ b/src/utils/repo.rs
@@ -26,7 +26,7 @@ use octocrab::Octocrab;
 use octocrab::models::repos::Object;
 use octocrab::params::repos::Reference;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::Write as _;
 use std::future::Future;
@@ -49,7 +49,7 @@ pub struct RepoInfo {
 
 /// Struct for holding tag information.
 /// This is for both annotated and lightweight tags.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TagInfo {
     /// Name of the tag
     pub name: String,
@@ -80,7 +80,7 @@ impl Hash for TagInfo {
 }
 
 /// The different types of tags
-#[derive(Debug, Deserialize, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum TagType {
     Annotated,
     Lightweight,


### PR DESCRIPTION
This adds a local filesystem cache for branches and tags, which makes repeat actions very fast compared to before.

This also contains similar fixes from ODP-6549, so that checking for missing branches/tags is also very fast, even if they aren't in the cache.

Libraries have been updated, security vulnerabilities fixed/ignored (as appropriate).

This doesn't implement caching for everything (such as repository checks) as of yet.

The default cache lifetime is 24 hours; that can be changed using a new cli flag, and `--update` can also be passed to force an update of the cache if one of the actions that uses a cache is run (except for checking missing).